### PR TITLE
[Bug] Add target_stack and env_private_dns_name to open hpds

### DIFF
--- a/app-infrastructure/template-renderer/main.tf
+++ b/app-infrastructure/template-renderer/main.tf
@@ -18,7 +18,10 @@ resource "aws_s3_object" "hpds_open_env" {
 
   bucket  = var.stack_s3_bucket
   key     = "configs/hpds/${var.target_stack}/open-hpds.env"
-  content = templatefile("${path.module}/templates/hpds-open.env.tftpl", {})
+  content = templatefile("${path.module}/templates/hpds-open.env.tftpl", {
+    target_stack         = var.target_stack
+    env_private_dns_name = var.env_private_dns_name
+  })
 
   content_type           = "text/plain"
   server_side_encryption = "AES256"


### PR DESCRIPTION
Updated the content of the S3 object to include target_stack and env_private_dns_name variables.