### PR TITLE
Consolidate BDC *:443 vhosts onto a single shared certificate

### DIFF
--- a/app-infrastructure/configs/httpd-vhosts-bdc.conf
+++ b/app-infrastructure/configs/httpd-vhosts-bdc.conf
@@ -28,8 +28,6 @@ SSLSessionCacheTimeout  300
 # Inert while a single *:443 vhost exists; enforces only if another is added.
 SSLVHostSNIPolicy strict
 
-# SSLStrictSNIVHostCheck stays off: it 403s non-SNI clients, and the container
-# healthcheck (https://0.0.0.0:443) cannot send SNI.
 
 Mutex  "file:$${HTTPD_PREFIX}/logs/ssl_mutex"
 

--- a/app-infrastructure/configs/httpd-vhosts-bdc.conf
+++ b/app-infrastructure/configs/httpd-vhosts-bdc.conf
@@ -25,7 +25,11 @@ SSLPassPhraseDialog  builtin
 SSLSessionCache        "shmcb:$${HTTPD_PREFIX}/logs/ssl_scache(512000)"
 SSLSessionCacheTimeout  300
 
-SSLVHostSNIPolicy insecure
+# Inert while a single *:443 vhost exists; enforces only if another is added.
+SSLVHostSNIPolicy strict
+
+# SSLStrictSNIVHostCheck stays off: it 403s non-SNI clients, and the container
+# healthcheck (https://0.0.0.0:443) cannot send SNI.
 
 Mutex  "file:$${HTTPD_PREFIX}/logs/ssl_mutex"
 
@@ -53,6 +57,7 @@ ServerTokens Prod
 
 <VirtualHost *:443>
     ServerName ${env_public_dns_name}
+    ServerAlias ${env_public_dns_name_staging}
     SSLProxyEngine on
     SSLProxyCheckPeerCN off
 
@@ -95,7 +100,13 @@ ServerTokens Prod
 
     # Match the request to /health and return a 200 OK status
     RewriteRule ^/picsure/health$ - [R=200,L]
-    
+
+    # Optional: reject unrecognised Host headers, which SSLVHostSNIPolicy cannot do
+    # with one vhost. Must stay below the health rule. Check the ALB health check
+    # path first - AWS probes send Host: <target-ip> and would get 421.
+    # RewriteCond %%{HTTP_HOST} !^(${env_public_dns_name}|${env_public_dns_name_staging})(:[0-9]+)?$ [NC]
+    # RewriteRule .* - [R=421,L]
+
     RewriteRule ^/picsure/(.*)$ "http://wildfly.${target_stack}.${env_private_dns_name}:8080/pic-sure-api-2/PICSURE/$1" [P]
     RewriteRule ^/psama/(.*)$ "http://wildfly.${target_stack}.${env_private_dns_name}:8090/auth/$1" [P]
     RewriteRule ^/psamaui/login/(.*)$ "http://localhost:3000/login/loading/$1" [P,QSA]
@@ -124,80 +135,3 @@ ServerTokens Prod
          downgrade-1.0 force-response-1.0
 
 </VirtualHost>
-
-<VirtualHost *:443>
-    ServerName ${env_public_dns_name_staging}
-    SSLProxyEngine on
-    SSLProxyCheckPeerCN off
-
-    SSLCertificateFile "$${HTTPD_PREFIX}/cert/preprod_server.crt"
-    SSLCertificateKeyFile "$${HTTPD_PREFIX}/cert/preprod_server.key"
-    SSLCertificateChainFile "$${HTTPD_PREFIX}/cert/preprod_server.chain"
-
-    Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains; preload"
-
-    # Content security policy:
-    # frame-ancestors 'none' - Stops our application from being loaded in an iframe
-    # default-src - Restricts loading resources to the same origin
-    # script-src - Allows inline scripts but only from the same origin and unsafe-eval and unsafe-inline
-    # unsafe-eval - Allows eval() and similar constructs
-    # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
-    # style-src - Allows inline styles but only from the same origin
-    # img-src - Allows images from the same origin and data: URIs
-    # https://www.googletagmanager.com - is needed for Google Analytics
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data: https://*.googletagmanager.com; img-src 'self' data: https://public.era.nih.gov blob: https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;"
-
-    # Attempt to prevent some MIME-type confusion attacks. There is no perfect solution to this problem.
-    Header always set X-Content-Type-Options "nosniff"
-
-    # Enables built-in XSS protection in modern web browsers.
-    # If a XSS is detected mode=block will block the entire page.
-    # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
-    Header always set X-Frame-Options "DENY"
-
-    # Enables built-in XSS protection in modern web browsers.
-    # If a XSS is detected mode=block will block the entire page.
-    Header always set X-XSS-Protection "1; mode=block;"
-
-    RewriteEngine On
-    ProxyPreserveHost On
-
-    #Dont allow httpd debug methods
-    RewriteCond %%{REQUEST_METHOD} ^TRACK
-    RewriteRule .* - [F]
-    RewriteCond %%{REQUEST_METHOD} ^TRACE
-    RewriteRule .* - [F]
-
-    # Match the request to /health and return a 200 OK status
-    RewriteRule ^/picsure/health$ - [R=200,L]
-    
-    RewriteRule ^/picsure/(.*)$ "http://wildfly.${target_stack}.${env_private_dns_name}:8080/pic-sure-api-2/PICSURE/$1" [P]
-    RewriteRule ^/psama/(.*)$ "http://wildfly.${target_stack}.${env_private_dns_name}:8090/auth/$1" [P]
-    RewriteRule ^/psamaui/login/(.*)$ "http://localhost:3000/login/loading/$1" [P,QSA]
-    RewriteRule ^/(.*)$ "http://localhost:3000/$1" [P]
-
-    RewriteCond %%{DOCUMENT_ROOT}/%%{REQUEST_FILENAME} !-f
-    RewriteCond %%{DOCUMENT_ROOT}/%%{REQUEST_FILENAME} !-d
-
-    DocumentRoot "$${HTTPD_PREFIX}/htdocs"
-
-    LogFormat "%%{X-Forwarded-For}i %t %%{SSL_PROTOCOL}x %%{SSL_CIPHER}x \"%r\" %b" proxy-ssl
-    LogFormat "%h %l %u %t \"%r\" %>s %b \"%%{Referer}i\" \"%%{User-Agent}i\"" combined
-    LogFormat "%%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%%{Referer}i\" \"%%{User-Agent}i\"" proxy
-    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-	RequestHeader set X-Forwarded-For "%%{REMOTE_ADDR}s" env=!forwarded
-    CustomLog "$${HTTPD_PREFIX}/logs/access_log" combined env=!forwarded
-    CustomLog "$${HTTPD_PREFIX}/logs/access_log" proxy env=forwarded
-    CustomLog "$${HTTPD_PREFIX}/logs/ssl_request_log" proxy-ssl env=forwarded
-    CustomLog "$${HTTPD_PREFIX}/logs/ssl_request_log" \
-          "%t %h %%{SSL_PROTOCOL}x %%{SSL_CIPHER}x \"%r\" %b" env=!forwarded
-    ErrorLog "$${HTTPD_PREFIX}/logs/error_log"
-    TransferLog "$${HTTPD_PREFIX}/logs/access_log"
-
-    BrowserMatch "MSIE [2-5]" \
-         nokeepalive ssl-unclean-shutdown \
-         downgrade-1.0 force-response-1.0
-
-</VirtualHost>
-
-


### PR DESCRIPTION
One certificate now covers both public hostnames (dev + predev, or prod + preprod), so the two *:443 VirtualHosts no longer need to be separate.